### PR TITLE
Allow freezing in the physics gun

### DIFF
--- a/scripts/weapon_physgun.txt
+++ b/scripts/weapon_physgun.txt
@@ -1,26 +1,26 @@
 // Physics Gun
-
 WeaponData
 {
 	// Weapon data is loaded by both the Game and Client DLLs.
-	"printname"	"#HL2_Physgun"
-	"viewmodel"				"models/weapons/v_superphyscannon.mdl"
-	"playermodel"			"models/weapons/w_Physics.mdl"
-	"anim_prefix"			"physgun"
-	"bucket"				"0"
-	"bucket_position"		"3"
+	"printname"		"PHYSICS GUN"
+	"viewmodel"		"models/weapons/v_superphyscannon.mdl"
+	"playermodel"		"models/weapons/w_Physics.mdl"
+	"anim_prefix"		"physgun"
+	"bucket"		"0"
+	"bucket_position"	"3"
 
-	"clip_size"				"-1"
-	"clip2_size"			"-1"
-	"primary_ammo"			"None"
-	"secondary_ammo"		"None"
+	"clip_size"		"-1"
+	"primary_ammo"		"None"
+	"secondary_ammo"	"Gravity"
 
-	"weight"				"0"
-	"item_flags"			"2"
+	"weight"			"2"
+	"item_flags"			"0"
+	"damage"			"99999999999999999999999999999999999999999999999999999999999999999999"
 
+	// Sounds for the weapon. There is a max of 16 sounds per category (i.e. max 16 "single_shot" sounds)
 	SoundData
 	{
-		"single_shot"		"Weapon_Physgun.On"
+				"single_shot"		"Weapon_Physgun.On"
 		"reload"			"Weapon_Physgun.Off"
 		"special1"			"Weapon_Physgun.Special1"
 	}
@@ -30,26 +30,29 @@ WeaponData
 	{
 		"weapon"
 		{
-				"font"		"WeaponIcons"
-				"character"	"m"
+				"file"		"sprites/w_icons4b"
+				"x"			"0"
+				"y"			"64"
+				"width"		"128"
+				"height"	"64"
 		}
 		"weapon_s"
-		{	
-				"font"		"WeaponIconsSelected"
-				"character"	"m"
+		{
+				"file"		"sprites/w_icons4b"
+				"x"			"0"
+				"y"			"64"
+				"width"		"128"
+				"height"	"64"
+		}
+		"ammo2"
+		{
+				"font"		"WeaponIcons"
+				"character"	"z"
 		}
 		"crosshair"
 		{
 				"font"		"Crosshairs"
 				"character"	"Q"
-		}
-		"autoaim"
-		{
-			"file"		"sprites/crosshairs"
-			"x"			"48"
-			"y"			"72"
-			"width"		"24"
-			"height"	"24"
 		}
 		"autoaim"
 		{


### PR DESCRIPTION
Instead of clicking `E` to freeze you can now right click